### PR TITLE
Add content length header to the request.

### DIFF
--- a/lib/GeckoboardPushSend.js
+++ b/lib/GeckoboardPushSend.js
@@ -10,11 +10,20 @@ function GeckoboardPushSend(params){
 
 GeckoboardPushSend.prototype.send = function(data, callback){
   var self = this;
+
+  var body = JSON.stringify({
+    api_key: self.options.api_key,
+    data: data
+  })
+
   var req = https.request({
     host: self.options.hostname,
     port: self.options.port,
     path: self.options.geckoPath,
-    method: self.options.method
+    method: self.options.method,
+    headers: {
+      'Content-Length': body.length
+    }
   }, function(res) {
     res.setEncoding('utf8');
     var response = '';
@@ -36,7 +45,7 @@ GeckoboardPushSend.prototype.send = function(data, callback){
         }
       }
     }).on('close', function(){
-    
+
     });
   });
 
@@ -47,12 +56,7 @@ GeckoboardPushSend.prototype.send = function(data, callback){
   });
 
   // write data to request body
-  req.write(
-    JSON.stringify({
-      api_key: self.options.api_key,
-      data: data 
-    })
-  );
+  req.write(body);
 
   req.end();
 }


### PR DESCRIPTION
Web servers like nginx expect a content length or will respond with 411.
