### PR TITLE
Calculate "Content-Length" header correctly when JSON includes multibyte...

### DIFF
--- a/lib/GeckoboardPushSend.js
+++ b/lib/GeckoboardPushSend.js
@@ -1,4 +1,5 @@
 var https = require('https');
+var Buffer = require('buffer').Buffer;
 
 module.exports = GeckoboardPushSend;
 

--- a/lib/GeckoboardPushSend.js
+++ b/lib/GeckoboardPushSend.js
@@ -22,7 +22,7 @@ GeckoboardPushSend.prototype.send = function(data, callback){
     path: self.options.geckoPath,
     method: self.options.method,
     headers: {
-      'Content-Length': body.length
+      'Content-Length': Buffer.byteLength(body)
     }
   }, function(res) {
     res.setEncoding('utf8');


### PR DESCRIPTION
... UTF-8 code points.